### PR TITLE
Provide option to output csv to visually check what was imported

### DIFF
--- a/tx_salaries/management/commands/import_salary_data.py
+++ b/tx_salaries/management/commands/import_salary_data.py
@@ -56,3 +56,10 @@ class Command(BaseCommand):
                 out('\n')
 
             to_db.denormalize(to_denormalize)
+
+            print "Finished processing %s" % basename(filename)
+            question = 'Would you like a summary of what was imported? y/n\n'
+            summary_choice = raw_input(question)
+            if summary_choice == 'y':
+                transformer.summarize_import(to_denormalize['organizations'],
+                                             'summary-' + basename(filename))

--- a/tx_salaries/management/commands/import_salary_data.py
+++ b/tx_salaries/management/commands/import_salary_data.py
@@ -61,5 +61,7 @@ class Command(BaseCommand):
             question = 'Would you like a summary of what was imported? y/n\n'
             summary_choice = raw_input(question)
             if summary_choice == 'y':
+                outfile = basename(filename)
+                outfile = outfile.split('.')[0] + '.csv'
                 transformer.summarize_import(to_denormalize['organizations'],
-                                             'summary-' + basename(filename))
+                                             'summary-' + outfile)

--- a/tx_salaries/utils/transformer.py
+++ b/tx_salaries/utils/transformer.py
@@ -71,6 +71,7 @@ def summarize_import(organizations, filename):
         'Title',
         'Department',
         'Gender',
+        'Ethnicity',
         'Hire_date',
         'Tenure',
         'Annual_salary',
@@ -82,6 +83,7 @@ def summarize_import(organizations, filename):
         'post__label',
         'organization__name',
         'person__gender',
+        'person__races__name',
         'employee__hire_date',
         'employee__tenure',
         'employee__compensation',
@@ -100,10 +102,11 @@ def summarize_import(organizations, filename):
                 'Title': val[member_kwargs[1]],
                 'Department': val[member_kwargs[2]],
                 'Gender': val[member_kwargs[3]],
-                'Hire_date': val[member_kwargs[4]],
-                'Tenure': val[member_kwargs[5]],
-                'Annual_salary': val[member_kwargs[6]],
-                'Entity': val[member_kwargs[7]]
+                'Ethnicity': val[member_kwargs[4]],
+                'Hire_date': val[member_kwargs[5]],
+                'Tenure': val[member_kwargs[6]],
+                'Annual_salary': val[member_kwargs[7]],
+                'Entity': val[member_kwargs[8]]
             })
 
     outfile.close()

--- a/tx_salaries/utils/transformer.py
+++ b/tx_salaries/utils/transformer.py
@@ -62,3 +62,49 @@ def get_transformers(labels):
         return TRANSFORMERS[generate_key(labels)]
     except KeyError:
         raise exceptions.ImproperlyConfigured()
+
+
+def summarize_import(organizations, filename):
+    from csv import DictWriter
+    columns = (
+        'Name',
+        'Title',
+        'Department',
+        'Gender',
+        'Hire_date',
+        'Tenure',
+        'Annual_salary',
+        'Entity',
+    )
+
+    member_kwargs = (
+        'person__name',
+        'post__label',
+        'organization__name',
+        'person__gender',
+        'employee__hire_date',
+        'employee__tenure',
+        'employee__compensation',
+        'organization__parent__name'
+    )
+
+    outfile = open(filename, 'w')
+    writer = DictWriter(outfile, columns)
+    writer.writerow(dict(zip(columns, columns)))
+
+    for org in organizations:
+        employee_values = org.members.values(*member_kwargs).distinct()
+        for val in employee_values:
+            writer.writerow({
+                'Name': val[member_kwargs[0]],
+                'Title': val[member_kwargs[1]],
+                'Department': val[member_kwargs[2]],
+                'Gender': val[member_kwargs[3]],
+                'Hire_date': val[member_kwargs[4]],
+                'Tenure': val[member_kwargs[5]],
+                'Annual_salary': val[member_kwargs[6]],
+                'Entity': val[member_kwargs[7]]
+            })
+
+    outfile.close()
+    print "Created %s" % filename


### PR DESCRIPTION
Even when a transformer runs without I errors, I often need to fix for whitespace or capitalization errors. This outputs a csv of what was just imported as it appears in the database so I can check for these errors at a glance.

I'll be using this to check all the transformers in #11 

TODO
- [ ] document what to look for in the summary file
- [ ] this doesn't test stats were calculated correctly... it could make a separate csv of stats and user could compare to the original?
