### PR TITLE
Add more descriptive exceptions for common error when creating test Posts

### DIFF
--- a/example/app/tests/management/commands/denormalize_salary_data.py
+++ b/example/app/tests/management/commands/denormalize_salary_data.py
@@ -14,8 +14,10 @@ class DenormalizeCreatesStats(TestCase):
 
         post = PostFactory(organization=child_org)
 
-        # POST MUST HAVE UNICODE VALUE
-        membership = MembershipFactory(post=post, organization=child_org)
+        try:
+            membership = MembershipFactory(post=post, organization=child_org)
+        except TypeError:
+            raise Exception('Could not create a Post. Did you give a unicode value in the tx_people sitepackages?')
 
         employee = EmployeeFactory(position=membership)
 
@@ -32,8 +34,10 @@ class DenormalizeCreatesStats(TestCase):
 
         post = PostFactory(organization=child_org)
 
-        # POST MUST HAVE UNICODE VALUE
-        membership = MembershipFactory(post=post, organization=child_org)
+        try:
+            membership = MembershipFactory(post=post, organization=child_org)
+        except TypeError:
+            raise Exception('Could not create a Post. Did you give a unicode value in the tx_people sitepackages?')
 
         employee = EmployeeFactory(position=membership)
 

--- a/example/app/tests/managers.py
+++ b/example/app/tests/managers.py
@@ -12,11 +12,13 @@ class EvenEmployeeMedianTest(TestCase):
         department = OrganizationFactory(name="Test Organization",
                                            parent=parent_org)
         post = PostFactory(organization=department)
-        # POST MUST HAVE UNICODE VALUE
-        membership_one = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
-        membership_two = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
+        try:
+            membership_one = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
+            membership_two = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
+        except TypeError:
+            raise Exception('Could not create a Post. Did you give a unicode value in the tx_people sitepackages?')
 
         # create two employees
         employee_one = EmployeeFactory(compensation=135000,
@@ -36,11 +38,14 @@ class EvenEmployeeMedianTest(TestCase):
         department = OrganizationFactory(name="Test Organization",
                                            parent=parent_org)
         post = PostFactory(organization=department)
-        # POST MUST HAVE UNICODE VALUE
-        membership_one = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
-        membership_two = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
+
+        try:
+            membership_one = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
+            membership_two = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
+        except TypeError:
+            raise Exception('Could not create a Post. Did you give a unicode value in the tx_people sitepackages?')
 
         # create two employees
         employee_one = EmployeeFactory(compensation=135000,
@@ -57,11 +62,14 @@ class RatiosAddUpTest(TestCase):
         department = OrganizationFactory(name="Test Organization",
                                            parent=parent_org)
         post = PostFactory(organization=department)
-        # POST MUST HAVE UNICODE VALUE
-        membership_one = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
-        membership_two = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
+
+        try:
+            membership_one = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
+            membership_two = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
+        except TypeError:
+            raise Exception('Could not create a Post. Did you give a unicode value in the tx_people sitepackages?')
 
         membership_three = MembershipFactory(post=post, organization=department,
                                              person__gender='M')
@@ -104,17 +112,21 @@ class RatiosAddUpTest(TestCase):
         department = OrganizationFactory(name="Test Organization",
                                            parent=parent_org)
         post = PostFactory(organization=department)
-        # POST MUST HAVE UNICODE VALUE
-        membership_one = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
-        membership_two = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
 
-        membership_three = MembershipFactory(post=post, organization=department,
-                                             person__gender='M')
+        try:
+          membership_one = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
+          membership_two = MembershipFactory(post=post, organization=department,
+                                             person__gender='F')
 
-        membership_four = MembershipFactory(post=post, organization=department,
-                                            person__gender='M')
+          membership_three = MembershipFactory(post=post, organization=department,
+                                               person__gender='M')
+
+          membership_four = MembershipFactory(post=post, organization=department,
+                                              person__gender='M')
+        except TypeError:
+            raise Exception('Could not create a Post. Did you give a unicode value in the tx_people sitepackages?')
+
         female_one = EmployeeFactory(compensation=135000,
                                        position=membership_one,
                                        tenure=self.calculate_tenure('1975-04-10', date.today()))
@@ -144,17 +156,21 @@ class RatiosAddUpTest(TestCase):
         department = OrganizationFactory(name="Test Organization",
                                            parent=parent_org)
         post = PostFactory(organization=department)
-        # POST MUST HAVE UNICODE VALUE
-        membership_one = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
-        membership_two = MembershipFactory(post=post, organization=department,
-                                           person__gender='F')
 
-        membership_three = MembershipFactory(post=post, organization=department,
-                                             person__gender='M')
+        try:
+            membership_one = MembershipFactory(post=post, organization=department,
+                                               person__gender='F')
+            membership_two = MembershipFactory(post=post, organization=department,
+                                               person__gender='F')
 
-        membership_four = MembershipFactory(post=post, organization=department,
-                                            person__gender='M')
+            membership_three = MembershipFactory(post=post, organization=department,
+                                                 person__gender='M')
+
+            membership_four = MembershipFactory(post=post, organization=department,
+                                                person__gender='M')
+        except TypeError:
+            raise Exception('Could not create a Post. Did you give a unicode value in the tx_people sitepackages?')
+
         female_one = EmployeeFactory(compensation=135000,
                                        position=membership_one)
         female_two = EmployeeFactory(compensation=62217,


### PR DESCRIPTION
Because tests will fail by default if user doesn't make a unicode value for Post.

TODO
- there must be a way to raise this error earlier in the factory
- explain this testing caveat in the documentation
- add a unicode value in `tx_people` ?
