### PR TITLE
remove PIL 

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,4 +1,3 @@
-PIL==1.1.7
 django-appconf==0.6
 django-jsonfield==0.9.10
 dj-database-url==0.2.1


### PR DESCRIPTION
remove `PIL` from requirements
#### What's this PR do?
- removes `PIL` from `requirements.txt`
#### Why am I doing this?  How does this help us?
- `PIL` is deprecated and needs to die; it's not required of this package anyway.  It was a requirement of a dependency (`tx_people`)
