### PR TITLE
Need django-jsonfield to come along when installed as a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     package_data={'tx_salaries': data_files},
     install_requires=[
         'csvkit==0.8',
-        'django-jsonfield==0.9',
+        'django-jsonfield>=0.9',
         'name_cleaver==0.6.0',
         'tx_people>=0.3.0',
     ],


### PR DESCRIPTION
Goes along with https://github.com/texastribune/salaries.texastribune.org/pull/53
