### PR TITLE
Add check for parent=None to determine if entity is top level

### DIFF
--- a/tx_salaries/management/commands/import_salary_data.py
+++ b/tx_salaries/management/commands/import_salary_data.py
@@ -71,7 +71,8 @@ class Command(BaseCommand):
 
         try:
             existing_org = models.Organization.objects.get(
-                name=records[0]['tx_people.Organization']['name'])
+                name=records[0]['tx_people.Organization']['name'],
+                parent=None)
         except models.Organization.DoesNotExist:
             existing_org = None
 


### PR DESCRIPTION
The check for existing entities should only check top level – otherwise it'll force deletions of minor departments that happen to have the same name. Also would have broken if two `Organization`s happened to have the same name.

Resolves #70 