### PR TITLE
Do not include any organizations that do not have stats yet

### DIFF
--- a/tx_salaries/models.py
+++ b/tx_salaries/models.py
@@ -23,7 +23,7 @@ def get_top_level_departments():
     Note: This only works for the current situation of non-nested
     departments.
     """
-    return Organization.objects.filter(parent=None)
+    return Organization.objects.filter(parent=None, stats__isnull=False)
 
 
 class CompensationType(models.Model):


### PR DESCRIPTION
This leads to breaking of the live site when an update runs. Because the `slug` for an `Organization` lives on its `OrganizationStats` model, things are limbo during an update. Because the stats do not exist at first, there's no slug to find, which leads to the template crashing and burning. Fun times.