### PR TITLE
We do a check against a TransformedRecord's self defined is_valid pro…

### DIFF
--- a/tx_salaries/utils/transformers/base.py
+++ b/tx_salaries/utils/transformers/base.py
@@ -62,9 +62,6 @@ class BaseTransformedRecord(object):
         return cleaver.EmployeeNameCleaver
 
     def as_dict(self):
-        # Stop early if this isn't valid
-        if not self.is_valid:
-            return
 
         # Build the structured record with the required attributes
         d = copy(DEFAULT_DATA_TEMPLATE)


### PR DESCRIPTION
…perty here, and if is_valid is False, we bail out and return None. None gets appended to the list of records to return which subsequently crashes import_file in import_salary_data when it is encountered.

Thankfully, this never happens, because all of our transform functions don't generate lists with invalid records. They access the same property to determine whether to append the return value from record's as_dict method in the first place. Which renders the check in as_dict redundant and irrelevant.

Summing up, this code never runs. If it did run, it would break everything. Taking it out will allow changes that follow to modify code upstream and downstream without a nasty and hard to trace surprise.
#99 